### PR TITLE
Making Font Awesome Icons more flexible

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,22 +138,22 @@ There are certain sections of the theme you can customize, in order to do so,
     github:
       title: Github
       url: <url>
-      icon: fa-github
+      icon: fab fa-github
       rel: me (disabled by default, add to activate)
     twitter:
       title: Twitter
       url: <url>
-      icon: fa-twitter
+      icon: fab fa-twitter
       rel: me (disabled by default, add to activate)
     linkedin:
       title: LinkedIn
       url: <url>
-      icon: fa-linkedin-in
+      icon: fab fa-linkedin-in
       rel: me (disabled by default, add to activate)
     stackoverflow:
       title: StackOverflow
       url: <url>
-      icon: fa-stack-overflow
+      icon: fab fa-stack-overflow
       rel: me (disabled by default, add to activate)
 
   # Navigation links (prev/next) on post page (enabled by default)
@@ -175,7 +175,7 @@ A couple of pointers for social media icons,
     facebook:
       title: Facebook
       url: <url>
-      icon: fa-facebook-f   
+      icon: fab fa-facebook-f
    ```
 
 # Third Party Libraries Used

--- a/templates/partials/footer.html.twig
+++ b/templates/partials/footer.html.twig
@@ -4,7 +4,7 @@
       {% for type, meta in theme_config.social %}
         <li>
           <a href="{{ meta.url }}" {% if meta.rel %}rel="{{ meta.rel }}" {% endif %}class="btn btn-link" title="{{ meta.title }}">
-            <i class="fab {{ meta.icon }}"></i>
+            <i class="{{ meta.icon }}"></i>
           </a>
           {% if loop.last == false %}
             <span class="separator">•</span>


### PR DESCRIPTION
This change makes Font Awesome icons a bit more flexible, but moves the "fa" and "fab" etc. code to the customization yml. I had to make this change to my own theme customization as example cause I wasn't able to use the E-Mail symbol initially since "fab" is only ever used for brand icons, think this is simply a more flexible solution for this problem also for other icons.